### PR TITLE
Support Winston 3.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ class Winston {
    * @param {{}} winstonOptions
    */
   constructor(transports = DEFAULT_TRANSPORTS, winstonOptions = {exitOnError: true}) {
-    this._logger = new winston.Logger(Object.assign(
+    this._logger = winston.createLogger(Object.assign(
       {exitOnError: true},
       winstonOptions,
       {transports: transports}


### PR DESCRIPTION
In Winston 3.0 support for create object using ```new winston.Logger``` was
removed - see https://github.com/winstonjs/winston/commit/eff6f00588ea6e7fcfc0a33bcf049ad85c76b6d9

This pull request supports the current version of Winston by using ```winston.createLogger``` instead.